### PR TITLE
fix: Wrong indexing in .A.matrix() generates error

### DIFF
--- a/R/designMatrices_aux2.R
+++ b/R/designMatrices_aux2.R
@@ -155,7 +155,8 @@
 				xsi.elim.index <- c( xsi.elim.index , 
 							which( colnames(mm.sg.temp ) %in% i3 ) )
 #				mm.sg.temp[  , i3 ] <- NA
-				mm.sg.temp[ ! ( is.na( mm.sg.temp[  , i3 ] ) ) , i3 ] <- 0
+        # modified indexing
+				mm.sg.temp[ , i3 ][ ! ( is.na( mm.sg.temp[  , i3 ] ) )] <- 0
 							}
 						}
 					}	


### PR DESCRIPTION
The R script below describes the issue:

``` Rscript
# Script created from the EXAMPLE 9 from the help page for tam.mml.mfr
require(TAM)

data(sim.mfr) ; data(sim.facets)
# When all items have the same number of categories and we specify the model
# with an interaction of three terms all works as expected
three_terms <- ~ item + item:step + female:item:step
mod9b <- tam.mml.mfr( resp=sim.mfr , facets=sim.facets , formulaA = three_terms)
summary(mod9b)

# But it stops working when at least one variable has less categories then maxK

# reducing the number of categories for V2
sim.mfr2 = as.data.frame(sim.mfr)
sim.mfr2[sim.mfr2$V2 == 3, "V2"] = 2

# the function then crashes on creating the design matrix A
mod9c <- tam.mml.mfr(resp=sim.mfr2 , facets=sim.facets , formulaA = three_terms)

# the error is generated by the function .A.matrix2() from designMatrices_aux2.R
# Here is the relevant part of the code (it starts in line 142 of the script):
# sg1 <- strsplit( sg , split= "-")[[1]]
# ii <- as.numeric( gsub("item" , "" , sg1[1] ) )
# if ( maxKi[ii] < maxK ){
#   for (kk in (maxKi[ii]+1):maxK){
#     #         kk <- 2
#     # set rows in A matrix to zero
#     mm.sg.temp[ grep( paste0( "-step" , kk ) , rownames(mm.sg.temp) ) ,  ] <- NA                          
#     #         mm.sg.temp[ grep( paste0( "-step" , kk ) , rownames(mm.sg.temp) ) ,  ] <- 0                         
#     i1 <- grep( paste0(sg1[1] ,"\\:" ) , colnames(mm.sg.temp) , value=TRUE)
#     i2 <- grep( paste0(":step" , kk-1) ,  colnames(mm.sg.temp) , value=TRUE)          
#     i3 <- intersect( i1 , i2 )            
#     if ( length(i3) > 0 ){
#       xsi.elim <- c( xsi.elim , i3 )
#       xsi.elim.index <- c( xsi.elim.index , 
#                            which( colnames(mm.sg.temp ) %in% i3 ) )
#       #               mm.sg.temp[  , i3 ] <- NA
#       #########################################
#       # !!! Next line causes a crash - the index is a matrix and not a vector!
#       #########################################
#     mm.sg.temp[ ! ( is.na( mm.sg.temp[  , i3 ] ) ) , i3 ] <- 0
#     }
#   }
# }

# I have submitted my proposal of change but I'm not sure that it works
# properly. For simpler models (with the interaction of two terms) it produces
# the same results as the original version.

# simple formula
two_terms = ~ item + item:step + female:item

# Run with original version of .A.matrix2()
mod10_o = tam.mml.mfr( resp=sim.mfr2  ,facets=sim.facets , formulaA = two_terms )

# Run with changed version of .A.matrix2()
mod10_c = tam.mml.mfr( resp=sim.mfr2  ,facets=sim.facets , formulaA = two_terms )

# Compare results
mod10_o$xsi
mod10_c$xsi

# But for the more complex models (with an interaction of three terms) it
# estimates infinite standard error for the interactions of the highest step of
# an item with the third term (V2:step3:female1 in this example).

mod11 <-tam.mml.mfr(resp=sim.mfr2, facets=sim.facets, formulaA = three_terms )
mod11$xsi
```
